### PR TITLE
Fix double free

### DIFF
--- a/src/shared/direct.c
+++ b/src/shared/direct.c
@@ -179,6 +179,7 @@ int buxton_direct_get_value_for_layer(BuxtonControl *control,
 		    !buxton_check_smack_access(client_label, data_label, ACCESS_READ)) {
 			/* Client lacks permission to read the value */
 			free(data_label->value);
+			data_label->value = NULL;
 			ret = EPERM;
 			goto fail;
 		}


### PR DESCRIPTION
When buxton_check_smack_access() in buxton_direct_get_value_for_layer() returns
false, data_label->value is freed but the value is not cleared. and, it is
freed again in get_label() when buxton_direct_get_value() returns error.

valgrind result is as follows:

==4232== Invalid free() / delete / delete[] / realloc()
==4232==    at 0x483FF80: free (vg_replace_malloc.c:473)
==4232==    by 0x14551: get_label (daemon.c:853)
==4232==    by 0x14975: buxtond_handle_message (daemon.c:279)
==4232==    by 0x1514D: handle_client (daemon.c:1303)
==4232==    by 0x13AF3: main (main.c:363)
==4232==  Address 0x4b4cfa0 is 0 bytes inside a block of size 7 free'd
==4232==    at 0x483FF80: free (vg_replace_malloc.c:473)
==4232==    by 0x15DE5: buxton_direct_get_value_for_layer (direct.c:181)
==4232==    by 0x15E07: buxton_direct_get_value (direct.c:59)
==4232==    by 0x14515: get_label (daemon.c:835)
==4232==    by 0x14975: buxtond_handle_message (daemon.c:279)
==4232==    by 0x1514D: handle_client (daemon.c:1303)
==4232==    by 0x13AF3: main (main.c:363)
==4232==

Signed-off-by: Suchang Woo <suchang.woo@samsung.com>
Change-Id: Idbcaa80b60711969a285782e56a849145559283a