### PR TITLE
libsystemd-daemon to libsystemd dependency as per changes in systemd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ AH_BOTTOM([#endif])
 
 # PkgConfig tests
 PKG_CHECK_MODULES([CHECK], [check])
-PKG_CHECK_MODULES([SYSTEMD], [libsystemd-daemon])
+PKG_CHECK_MODULES([SYSTEMD], [libsystemd])
 
 # Checks for header files.
 AC_FUNC_ALLOCA


### PR DESCRIPTION
Libsystemd-daemon has been replaced by libsystemd since systemd v. 2.09. Libsystemd-daemon is now obsolete and therefore may not be available.
This fix was originally suggested by Patrick Ohly (pohly).