### PR TITLE
Fix Null check for calloc failure

### DIFF
--- a/src/shared/serialize.c
+++ b/src/shared/serialize.c
@@ -198,6 +198,7 @@ size_t buxton_serialize_message(uint8_t **dest, BuxtonControlMessage message,
 	uint16_t control, msg;
 
 	assert(dest);
+	assert(list);
 
 	buxton_debug("Serializing message...\n");
 


### PR DESCRIPTION
buxton_serialize_message() is called at many places after buxton_array_new() which returns memory allocated using calloc.
However, in rare conditions if calloc failed it will return Null & hence buxton_serialize_message() will dereference Null (list).
Adding assert(list) to fix such a case.