### PR TITLE
Fix Null return by strlwc

### DIFF
--- a/src/shared/iniparser.c
+++ b/src/shared/iniparser.c
@@ -405,6 +405,8 @@ char * iniparser_getstring(dictionary * d, const char * key, char * def)
         return def ;
 
     lc_key = strlwc(key);
+    if (lc_key==NULL)
+    	return def;
     sval = dictionary_get(d, lc_key, def);
     return sval ;
 }


### PR DESCRIPTION
strlwc at line 407 can return Null, in that case "lc_key" will be dereference using "strlen()" subsequently.
Return default value in such scenario.