### PR TITLE
Avoid strcpy to crash

### DIFF
--- a/src/shared/dictionary.c
+++ b/src/shared/dictionary.c
@@ -250,7 +250,7 @@ int dictionary_set(dictionary * d, const char * key, const char * val)
     int         i ;
     unsigned    hash ;
 
-    if (d==NULL || key==NULL) return -1 ;
+    if (d==NULL) return -1 ;
 
     /* Compute hash for this key */
     hash = dictionary_hash(key) ;
@@ -317,7 +317,7 @@ void dictionary_unset(dictionary * d, const char * key)
     unsigned    hash ;
     int         i ;
 
-    if (key == NULL) {
+    if (d == NULL) {
         return;
     }
 

--- a/src/shared/iniparser.c
+++ b/src/shared/iniparser.c
@@ -102,8 +102,6 @@ static char * strstrip(const char * s)
     static char l[ASCIILINESZ+1];
     char * last ;
 
-    if (s==NULL) return NULL ;
-
     while (isspace((int)*s) && *s) s++;
     memset(l, 0, ASCIILINESZ+1);
     strcpy(l, s);
@@ -592,7 +590,12 @@ static line_status iniparser_line(
     line_status sta ;
     char        line[ASCIILINESZ+1];
     int         len ;
-
+    
+    assert(input_line);
+    assert(section);
+    assert(key);
+    assert(value);
+    
     strcpy(line, strstrip(input_line));
     len = (int)strlen(line);
 

--- a/src/shared/iniparser.c
+++ b/src/shared/iniparser.c
@@ -72,7 +72,6 @@ static char * strlwc(const char * s)
     static char l[ASCIILINESZ+1];
     int i ;
 
-    if (s==NULL) return NULL ;
     memset(l, 0, ASCIILINESZ+1);
     i=0 ;
     while (s[i] && i<ASCIILINESZ) {
@@ -553,6 +552,7 @@ int iniparser_find_entry(
 /*--------------------------------------------------------------------------*/
 int iniparser_set(dictionary * ini, const char * entry, const char * val)
 {
+    assert(entry);
     return dictionary_set(ini, strlwc(entry), val) ;
 }
 
@@ -568,6 +568,7 @@ int iniparser_set(dictionary * ini, const char * entry, const char * val)
 /*--------------------------------------------------------------------------*/
 void iniparser_unset(dictionary * ini, const char * entry)
 {
+    assert(entry);
     dictionary_unset(ini, strlwc(entry));
 }
 


### PR DESCRIPTION
If strstrip return Null, it will crash strcpy.
strstrip is returning Null when input string is Null.
assert() check for inputs in iniparser_line() will avoid this errornous case.